### PR TITLE
Updated configure entitlements script for ios

### DIFF
--- a/scripts/configureEntitlementsIos.js
+++ b/scripts/configureEntitlementsIos.js
@@ -53,7 +53,7 @@ module.exports = function (ctx) {
         var projectPath = path.join(projFolder, 'project.pbxproj');
         var xcodeProject = xcode.project(projectPath);
 
-        var entitlementsFile = path.join(projName, "Resources/ADALiOS.entitlements");
+        var entitlementsFile = path.join("\"",projName, "Resources/ADALiOS.entitlements\"");
 
         console.log('Attempt to update xcode project: ' + projectPath);
 


### PR DESCRIPTION
Had to change a path.join statement so it can handle spaces in the project name (Cordova creates a build dir in the ios platform with the name as directory name). Spaces weren't being handled correct by the script thus made the iOS build fail.