### PR TITLE
Changed PromptBehavior from "always" to "auto"

### DIFF
--- a/src/windows/ADALProxy.js
+++ b/src/windows/ADALProxy.js
@@ -157,7 +157,7 @@ var ADALProxy = {
                             }, res);
                         }, fail);
                     } else {
-                        context.acquireTokenAsync(resourceUrl, clientId, redirectUrl, Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior.always, userIdentifier, extraQueryParameters).then(function (res) {
+                        context.acquireTokenAsync(resourceUrl, clientId, redirectUrl, Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior.auto, userIdentifier, extraQueryParameters).then(function (res) {
                             handleAuthResult(win, fail, res);
                         }, fail);
                     }


### PR DESCRIPTION
Changed PromptBehavior from "always" to "auto" for the normal (non-ADFS/corp network) path for Windows. The prior version results in an authentication prompt each time acquireTokenAsync is called. The documented behaviour is that acquireTokenAsync will attempt to find a cached token. If the cached token has expired it will attempt to use the cached refresh token to obtain a new access token. Only if all these are exhausted will the user be shown the authorization prompt.

Setting PromptBehavior to "always" means that the user is shown the authorization prompt every time the native acquireTokenAsync is called.