### PR TITLE
SO plugin doesn't add capabilities to package.windows10.appxmanifest

### DIFF
--- a/src/windows/sso/plugin.xml
+++ b/src/windows/sso/plugin.xml
@@ -17,12 +17,7 @@
             <runs />
         </js-module>
 
-        <config-file target="package.windows80.appxmanifest" parent="/Package/Capabilities">
-            <Capability Name="enterpriseAuthentication" />
-            <Capability Name="privateNetworkClientServer" />
-            <Capability Name="sharedUserCertificates" />
-        </config-file>
-        <config-file target="package.windows.appxmanifest" parent="/Package/Capabilities">
+        <config-file target="package.appxmanifest" parent="/Package/Capabilities" device-target="windows">
             <Capability Name="enterpriseAuthentication" />
             <Capability Name="privateNetworkClientServer" />
             <Capability Name="sharedUserCertificates" />


### PR DESCRIPTION
This closes #58 

[Corresponding plugin.xml docs](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#config-file) on device-target feature.