### PR TITLE
Try to fill 'userInfo' structure if 'idToken' is not defined in case of brokered authentication

### DIFF
--- a/www/AuthenticationResult.js
+++ b/www/AuthenticationResult.js
@@ -17,7 +17,16 @@ function AuthenticationResult(authResult) {
     this.statusCode = authResult.statusCode;
     this.tenantId = authResult.tenantId;
 
-    this.userInfo = authResult.idToken ? UserInfo.fromJWT(authResult.idToken) : null;
+    var jwtToken = authResult.idToken || authResult.accessToken;
+    this.userInfo = null;
+
+    if (jwtToken) {
+        this.userInfo = UserInfo.fromJWT(jwtToken);
+    }
+
+    if (!this.userInfo) {
+        this.userInfo = new UserInfo(authResult.userInfo);
+    }
 }
 
 /**


### PR DESCRIPTION
Related issue: https://github.com/AzureAD/azure-activedirectory-library-for-cordova/issues/127