### PR TITLE
FIX(iOS): NSDictionary of contexts is not thread safe (crash)

### DIFF
--- a/src/ios/CordovaAdalPlugin.h
+++ b/src/ios/CordovaAdalPlugin.h
@@ -12,6 +12,8 @@
 // Implements Apache Cordova plugin for Microsoft Azure ADAL
 @interface CordovaAdalPlugin : CDVPlugin
 
+- (void)pluginInitialize;
+
 // AuthenticationContext methods
 - (void)createAsync:(CDVInvokedUrlCommand *)command;
 - (void)acquireTokenAsync:(CDVInvokedUrlCommand *)command;
@@ -21,9 +23,6 @@
 - (void)tokenCacheClear:(CDVInvokedUrlCommand *)command;
 - (void)tokenCacheReadItems:(CDVInvokedUrlCommand *)command;
 - (void)tokenCacheDeleteItem:(CDVInvokedUrlCommand *)command;
-
-+ (ADAuthenticationContext *)getOrCreateAuthContext:(NSString *)authority
-                                  validateAuthority:(BOOL)validate;
 
 - (void)setLogger:(CDVInvokedUrlCommand *)command;
 - (void)setLogLevel:(CDVInvokedUrlCommand *) command;


### PR DESCRIPTION
Issue #166
NSDictionary is not thread safe, but its accessed in a background thread. This can cause crashes.
The crash is seen in our telemetry.
Please see the issue logs