### PR TITLE
Add return type definitions on promises

### DIFF
--- a/cordova-plugin-ms-adal.d.ts
+++ b/cordova-plugin-ms-adal.d.ts
@@ -35,11 +35,11 @@ declare namespace Microsoft {
         }
 
         interface IPromise {
-            then(doneCallBack: () => void, failCallBack?: (message: string) => void);
+            then(doneCallBack: () => void, failCallBack?: (message: string) => void): IPromise;
         }
 
         interface IPromiseTokenCacheItems {
-            then(doneCallBack: (tokenCacheItems: ITokenCacheItem[]) => void, failCallBack?: (message: string) => void);
+            then(doneCallBack: (tokenCacheItems: ITokenCacheItem[]) => void, failCallBack?: (message: string) => void): IPromiseTokenCacheItems;
         }
 
         class TokenCache implements ITokenCache {
@@ -101,7 +101,7 @@ declare namespace Microsoft {
         }
 
         interface IPromiseAuthenticationResult {
-            then(doneCallBack: (context: IAuthenticationResult) => void, failCallBack?: (message: string) => void);
+            then(doneCallBack: (context: IAuthenticationResult) => void, failCallBack?: (message: string) => void): IPromiseAuthenticationResult;
         }
 
         interface IAuthenticationContext {
@@ -142,7 +142,7 @@ declare namespace Microsoft {
         }
 
         interface IPromiseAuthenticationContext {
-            then(doneCallBack: (context: IAuthenticationContext) => void, failCallBack?: (message: string) => void);
+            then(doneCallBack: (context: IAuthenticationContext) => void, failCallBack?: (message: string) => void): IPromiseAuthenticationContext;
         }
 
         class AuthenticationContext implements IAuthenticationContext {


### PR DESCRIPTION
TypeScript 2.7 complains about these type definitions not having return types declared, in the default TypeScript configuration. I have added return types using the same type as the given promise, as it will pass through the same argument types.