### PR TITLE
Set PromptBehavior to Auto if extraQueryParameters contains 'prompt='

### DIFF
--- a/src/android/CordovaAdalPlugin.java
+++ b/src/android/CordovaAdalPlugin.java
@@ -40,6 +40,8 @@ import static com.microsoft.aad.adal.SimpleSerialization.tokenItemToJSON;
 public class CordovaAdalPlugin extends CordovaPlugin {
 
     private static final PromptBehavior SHOW_PROMPT_ALWAYS = PromptBehavior.Always;
+    private static final PromptBehavior SHOW_PROMPT_AUTO = PromptBehavior.Auto;
+
 
     private static final int GET_ACCOUNTS_PERMISSION_REQ_CODE = 0;
     private static final String PERMISSION_DENIED_ERROR =  "Permissions denied";
@@ -207,7 +209,7 @@ public class CordovaAdalPlugin extends CordovaPlugin {
                 clientId,
                 redirectUrl,
                 userId,
-                SHOW_PROMPT_ALWAYS,
+                (extraQueryParams != null && extraQueryParams.contains("prompt=")) ? SHOW_PROMPT_AUTO : SHOW_PROMPT_ALWAYS,
                 extraQueryParams,
                 new DefaultAuthenticationCallback(callbackContext));
     }

--- a/src/ios/CordovaAdalPlugin.m
+++ b/src/ios/CordovaAdalPlugin.m
@@ -63,7 +63,7 @@
                  acquireTokenWithResource:resourceId
                  clientId:clientId
                  redirectUri:redirectUri
-                 promptBehavior:AD_PROMPT_ALWAYS
+                 promptBehavior: (extraQueryParameters && [extraQueryParameters containsString: @"prompt="]) ? AD_PROMPT_AUTO : AD_PROMPT_ALWAYS
                  userId:userId
                  extraQueryParameters:extraQueryParameters
                  completionBlock:^(ADAuthenticationResult *result) {

--- a/src/windows/ADALProxy.js
+++ b/src/windows/ADALProxy.js
@@ -133,6 +133,7 @@ var ADALProxy = {
             var userId = args[5];
             var extraQueryParameters = args[6];
             var userIdentifier;
+            var defaultPromptBehavior = extraQueryParameters != undefined && extraQueryParameters.indexOf('prompt=') > -1 ? Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior.auto : Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior.always;
 
             ADALProxy.getOrCreateCtx(authority, validateAuthority).then(function (context) {
                 userIdentifier = getUserIdentifier(context, userId);
@@ -179,13 +180,13 @@ var ADALProxy = {
                         // Try to SSO first
                         context.acquireTokenAsync(resourceUrl, clientId, Windows.Security.Authentication.Web.WebAuthenticationBroker.getCurrentApplicationCallbackUri(), Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior.never, userIdentifier, extraQueryParameters).then(function (res) {
                             handleAuthResult(win, function() {
-                                context.acquireTokenAsync(resourceUrl, clientId, Windows.Security.Authentication.Web.WebAuthenticationBroker.getCurrentApplicationCallbackUri(), Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior.always, userIdentifier, extraQueryParameters).then(function (res) {
+                                context.acquireTokenAsync(resourceUrl, clientId, Windows.Security.Authentication.Web.WebAuthenticationBroker.getCurrentApplicationCallbackUri(), defaultPromptBehavior, userIdentifier, extraQueryParameters).then(function (res) {
                                     handleAuthResult(win, fail, res);
                                 }, fail);
                             }, res);
                         }, fail);
                     } else {
-                        context.acquireTokenAsync(resourceUrl, clientId, redirectUrl, Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior.always, userIdentifier, extraQueryParameters).then(function (res) {
+                        context.acquireTokenAsync(resourceUrl, clientId, redirectUrl, defaultPromptBehavior, userIdentifier, extraQueryParameters).then(function (res) {
                             handleAuthResult(win, fail, res);
                         }, fail);
                     }


### PR DESCRIPTION
This pull request fixes issue #167.

I've added a check on `extraQueryParameters`. If it contains `prompt=`, it will set PromptBehavior to Auto (instead of Always). This way, the ADAL plugin will not throw a 'duplicate prompt parameter' error message. 

Henceforth we are now able to force the consent flow if we want.