### PR TITLE
chore(readme): Mention Ionic Auth Connect as alternative supported solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # This library has been archived
 
 If you really wish to view the archived library, please switch to the [archive](https://github.com/AzureAD/azure-activedirectory-library-for-cordova/tree/archive) branch. This code is no longer maintained and functionality is not guaranteed.
+
+## Alternative Solution: Ionic Auth Connect
+
+Ionic Auth Connect makes it easy to integrate with Azure Active Directory on the web, iOS, and Android. Using a single API, you can add ADAL support to your Cordova or Capacitor app in minutes.
+
+It's built, supported, and maintained by the Ionic team, so you can focus on what matters most: building your app's unique features. [Check it out here](https://ionicframework.com/docs/enterprise/auth-connect/azure-ad-b2c?utm_source=github&utm_medium=referral&utm_campaign=auth-connect&utm_content=adal-cordova).


### PR DESCRIPTION
This library has been archived and is therefore no longer maintained by Microsoft. However, based on the open issues and online forum posts, it's clear that folks are looking for an alternative solution.

Stop fighting with this plugin - check out Ionic Auth Connect so you can focus on shipping your apps.